### PR TITLE
Enable auth rate limiting

### DIFF
--- a/server/routes/auth.routes.ts
+++ b/server/routes/auth.routes.ts
@@ -127,11 +127,11 @@ export function authRoutes(app: Express): void {
   
   // Versioned route (primary)
   app.post(
-    versionedLoginPath, 
+    versionedLoginPath,
     versionHeadersMiddleware(),
     verifyCsrf, // CSRF protection for login
-    // authRateLimiter, // Apply rate limiting to login endpoint (temporarily disabled)
-    // securityRateLimiter, // Apply security rate limiting to detect brute force attacks (temporarily disabled)
+    authRateLimiter, // Apply rate limiting to login endpoint
+    securityRateLimiter, // Apply security rate limiting to detect brute force attacks
     validate(authSchemas.login),
     async (req: Request, res: Response) => {
       try {

--- a/test/auth-rate-limit.test.ts
+++ b/test/auth-rate-limit.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+
+// Mock storage to always fail login verification
+jest.mock('../server/storage', () => ({
+  storage: {
+    verifyLogin: jest.fn().mockResolvedValue(null),
+    getUserByPhone: jest.fn(),
+    updateUser: jest.fn(),
+  }
+}));
+
+// Bypass CSRF protection for testing
+jest.mock('../server/middleware/csrfMiddleware', () => ({
+  verifyCsrf: (_req: any, _res: any, next: any) => next(),
+}));
+
+// Import after mocks are set up
+import { authRoutes } from '../server/routes/auth.routes';
+
+describe('Auth rate limiting', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    authRoutes(app);
+  });
+
+  it('throttles excessive login attempts', async () => {
+    const loginPayload = { email: 'test@example.com', password: 'wrongpassword' };
+
+    // First 5 attempts should be processed (and fail with 401 or similar)
+    for (let i = 0; i < 5; i++) {
+      await request(app).post('/api/v1/auth/login').send(loginPayload);
+    }
+
+    // Sixth attempt should hit rate limiter
+    const res = await request(app).post('/api/v1/auth/login').send(loginPayload);
+    expect(res.status).toBe(429);
+    expect(res.body.message).toMatch(/Too many authentication attempts/i);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce auth and security rate limiting on login route
- add test ensuring repeated login attempts trigger throttling

## Testing
- ⚠️ `npx jest test/auth-rate-limit.test.ts` (failed: module is not defined in ES module scope)

------
https://chatgpt.com/codex/tasks/task_e_68a67eb3b0e4832aacb915c1e348133d