### PR TITLE
feat: enable dynamic CSRF tokens

### DIFF
--- a/client/src/test-login.tsx
+++ b/client/src/test-login.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useLocation } from "wouter";
 import { apiRequest } from "@/lib/queryClient";
+import { resetCSRFToken } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -25,6 +26,7 @@ export default function TestLogin() {
       const csrfResponse = await fetch('/api/csrf-token', { credentials: 'include' });
       const csrfData = await csrfResponse.json();
       console.log('CSRF token obtained:', csrfData.csrfToken ? 'Yes' : 'No');
+      resetCSRFToken(csrfData.csrfToken);
 
       // Make the login request
       const response = await apiRequest('/api/v1/auth/login', {

--- a/server/index.ts
+++ b/server/index.ts
@@ -75,6 +75,16 @@ const limiter = rateLimit({
 });
 app.use(limiter);
 
+// CSRF protection middleware
+const csrfProtection = csurf({
+  cookie: {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict'
+  }
+});
+app.use(csrfProtection);
+
 // Skip admin API bypass for now
 // app.use('/api/direct/admin', adminBypassRouter);
 // console.log("Admin API bypass router mounted at /api/direct/admin");
@@ -98,9 +108,9 @@ app.get('/health', (req, res) => {
 
 // API routes - mount BEFORE Vite middleware to ensure they take precedence
 
-// Basic CSRF token endpoint
+// CSRF token endpoint using dynamic tokens
 app.get('/api/csrf-token', (req, res) => {
-  res.json({ csrfToken: 'dev-csrf-token' });
+  res.json({ csrfToken: req.csrfToken() });
 });
 
 // User status endpoint for auth context


### PR DESCRIPTION
## Summary
- use csurf middleware for CSRF protection
- return dynamic CSRF token from `/api/csrf-token`
- update test login page to store and reuse token

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check:server` *(fails: TS errors in server/storage.ts)*
- `npm run check:client` *(terminated: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68a67c1417dc832ab8ec3d17da6c85a4