### PR TITLE
Fix email confirmation handling in business registration

### DIFF
--- a/server/routes/auth.routes.ts
+++ b/server/routes/auth.routes.ts
@@ -176,14 +176,19 @@ export async function registerBusiness(req: Request, res: Response) {
     }
 
     // Call provisioner with validated phoneVerified
-    const { userId, emailConfirmed } = await provisionSupabaseUser({ 
-      email, 
-      password, 
-      phone, 
-      phoneVerified 
+    const { userId, email_confirmed } = await provisionSupabaseUser({
+      email,
+      password,
+      phone,
+      phoneVerified
     });
 
-    console.log("Supabase user provisioned:", userId, "emailConfirmed:", emailConfirmed);
+    console.log(
+      "Supabase user provisioned:",
+      userId,
+      "emailConfirmed:",
+      email_confirmed
+    );
 
     // Upsert profile in PostgreSQL database with conflict resolution
     const client = await pool.connect();


### PR DESCRIPTION
## Summary
- Destructure `email_confirmed` from `provisionSupabaseUser` in business registration route
- Return `emailConfirmed` in success response to avoid reference errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7bc010930832abc395bd6ec64c8bb