### PR TITLE
Add business verification feedback support

### DIFF
--- a/client/src/components/admin/BusinessReviewPanel.tsx
+++ b/client/src/components/admin/BusinessReviewPanel.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { 
   CheckCircle, 
   XCircle, 
@@ -32,6 +33,7 @@ interface Business {
   appliedDate: string;
   status: "new" | "in_review" | "approved" | "rejected";
   verificationStatus: string;
+  verificationFeedback?: string;
   email: string;
   phone: string;
   address: string;
@@ -195,7 +197,15 @@ export default function BusinessReviewPanel({ business, onStatusChange }: Busine
                 {formatDate(business.appliedDate)}
               </div>
             </div>
-            
+
+            {business.verificationFeedback && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Verification Feedback</AlertTitle>
+                <AlertDescription>{business.verificationFeedback}</AlertDescription>
+              </Alert>
+            )}
+
             <div className="space-y-2">
               <div className="text-sm font-medium">Contact Information</div>
               <div className="rounded-md border p-3 space-y-2">

--- a/client/src/pages/admin/vendors/[id].tsx
+++ b/client/src/pages/admin/vendors/[id].tsx
@@ -64,6 +64,7 @@ interface Business {
   appliedDate: string;
   status: "new" | "in_review" | "approved" | "rejected";
   verificationStatus: string;
+  verificationFeedback?: string;
   email: string;
   phone: string;
   address: string;
@@ -124,6 +125,7 @@ export default function VendorDetailPage() {
           appliedDate: response.applied_date || response.created_at || new Date().toISOString(),
           status: response.status || "new",
           verificationStatus: response.verification_status || "pending",
+          verificationFeedback: response.verification_feedback || "",
           email: response.email || "",
           phone: response.phone || "",
           address: response.address || "",
@@ -169,6 +171,7 @@ export default function VendorDetailPage() {
           appliedDate: new Date().toISOString(),
           status: "new",
           verificationStatus: "pending",
+          verificationFeedback: "",
           email: "vendor@test.com",
           phone: "(555) 123-4567",
           address: "123 Main St, Anytown USA",
@@ -235,11 +238,12 @@ export default function VendorDetailPage() {
         title: "Success",
         description: `Vendor ${status === "approved" ? "approved" : "rejected"} successfully`
       });
-      
+
       // Update local state
       setBusiness({
         ...business,
-        verificationStatus: status
+        verificationStatus: status,
+        verificationFeedback: feedbackText
       });
       setApprovalStatus(status);
       
@@ -458,13 +462,21 @@ export default function VendorDetailPage() {
                   : "Pending Approval"}
               </h3>
               <p className="text-sm text-muted-foreground text-center">
-                {business.verificationStatus === "approved" 
-                  ? "This vendor has been verified and can create deals." 
+                {business.verificationStatus === "approved"
+                  ? "This vendor has been verified and can create deals."
                   : business.verificationStatus === "rejected"
                   ? "This vendor has been rejected and cannot create deals."
                   : "This vendor is waiting for verification."}
               </p>
             </div>
+
+            {business.verificationFeedback && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Verification Feedback</AlertTitle>
+                <AlertDescription>{business.verificationFeedback}</AlertDescription>
+              </Alert>
+            )}
 
             <Separator />
 

--- a/client/src/pages/admin/vendors/index.tsx
+++ b/client/src/pages/admin/vendors/index.tsx
@@ -78,6 +78,7 @@ interface Business {
   appliedDate: string;
   status: "new" | "in_review" | "approved" | "rejected";
   verificationStatus: string;
+  verificationFeedback?: string;
   email: string;
   phone: string;
   address: string;
@@ -335,6 +336,7 @@ export default function VendorsPage() {
             appliedDate: business.applied_date || business.user?.created_at || business.created_at || new Date().toISOString(),
             status: business.status || "new",
             verificationStatus: business.verification_status || business.verificationStatus || "pending",
+            verificationFeedback: business.verification_feedback || business.verificationFeedback || "",
             email: business.email || business.user?.email || "",
             phone: business.phone || "",
             address: business.address || "",
@@ -706,8 +708,8 @@ export default function VendorsPage() {
                   </Button>
                 </TableHead>
                 <TableHead>
-                  <Button 
-                    variant="ghost" 
+                  <Button
+                    variant="ghost"
                     className="flex items-center gap-1 p-0 hover:bg-transparent"
                     onClick={() => handleSort("verificationStatus")}
                   >
@@ -719,13 +721,14 @@ export default function VendorsPage() {
                     )}
                   </Button>
                 </TableHead>
+                <TableHead>Feedback</TableHead>
                 <TableHead className="text-right">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="text-center py-10">
+                  <TableCell colSpan={7} className="text-center py-10">
                     <div className="flex items-center justify-center">
                       <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary"></div>
                     </div>
@@ -733,7 +736,7 @@ export default function VendorsPage() {
                 </TableRow>
               ) : filteredBusinesses.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="text-center py-10">
+                  <TableCell colSpan={7} className="text-center py-10">
                     <div className="flex flex-col items-center justify-center">
                       <Building className="h-12 w-12 text-muted-foreground mb-3" />
                       <p className="text-muted-foreground">No vendors found</p>
@@ -773,6 +776,11 @@ export default function VendorsPage() {
                     </TableCell>
                     <TableCell>{format(new Date(business.appliedDate), "MMM d, yyyy")}</TableCell>
                     <TableCell>{getStatusBadge(business.verificationStatus)}</TableCell>
+                    <TableCell>
+                      <span className="text-xs text-muted-foreground truncate max-w-[200px]">
+                        {business.verificationFeedback || "-"}
+                      </span>
+                    </TableCell>
                     <TableCell className="text-right">
                       <div className="flex justify-end gap-2">
                         <Button 

--- a/server/routes/business.routes.ts
+++ b/server/routes/business.routes.ts
@@ -230,8 +230,11 @@ export function businessRoutes(app: Express): void {
         }
         
         const updatedBusiness = await storage.updateBusinessVerificationStatus(businessId, status, feedback);
-        
-        return res.status(200).json(updatedBusiness);
+
+        return res.status(200).json({
+          ...updatedBusiness,
+          verificationFeedback: updatedBusiness.verificationFeedback,
+        });
       } catch (error) {
         console.error("Update business verification error:", error);
         return res.status(500).json({ message: "Internal server error" });
@@ -261,8 +264,11 @@ export function businessRoutes(app: Express): void {
         }
         
         const updatedBusiness = await storage.updateBusinessVerificationStatus(businessId, status, feedback);
-        
-        return res.status(200).json(updatedBusiness);
+
+        return res.status(200).json({
+          ...updatedBusiness,
+          verificationFeedback: updatedBusiness.verificationFeedback,
+        });
       } catch (error) {
         console.error("Update business verification error (legacy):", error);
         return res.status(500).json({ message: "Internal server error" });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1001,12 +1001,13 @@ export class MemStorage implements IStorage {
     if (!business) {
       throw new Error("Business not found");
     }
-    
+
     const updatedBusiness: Business = {
       ...business,
       verificationStatus: status,
+      verificationFeedback: feedback ?? null,
     };
-    
+
     this.businesses.set(id, updatedBusiness);
     return updatedBusiness;
   }
@@ -2451,8 +2452,9 @@ export class DatabaseStorage implements IStorage {
 
   async updateBusinessVerificationStatus(id: number, status: string, feedback?: string): Promise<Business> {
     const [updatedBusiness] = await db.update(businesses)
-      .set({ 
-        verificationStatus: status
+      .set({
+        verificationStatus: status,
+        verificationFeedback: feedback ?? null
       })
       .where(eq(businesses.id, id))
       .returning();

--- a/server/utils/sanitize.ts
+++ b/server/utils/sanitize.ts
@@ -83,6 +83,7 @@ export function sanitizeBusiness(business: any): any {
     businessName: business.businessName || "Untitled Business",
     businessCategory: business.businessCategory || "other",
     verificationStatus: business.verificationStatus || "pending",
+    verificationFeedback: business.verificationFeedback || "",
     description: business.description || "",
     address: business.address || "",
     latitude: business.latitude || 0,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -46,6 +46,7 @@ export const businesses = pgTable("businesses", {
   proofOfAddress: text("proof_of_address").notNull(), // File path/reference
   proofOfBusiness: text("proof_of_business").notNull(), // File path/reference
   verificationStatus: text("verification_status").notNull().default("pending"), // "pending", "verified", "rejected"
+  verificationFeedback: text("verification_feedback"),
   description: text("description"),
   address: text("address"),
   latitude: doublePrecision("latitude"),


### PR DESCRIPTION
## Summary
- add `verificationFeedback` column to business schema
- persist admin feedback in storage and API responses
- surface verification feedback on admin vendor pages

## Testing
- `npm run check:server`
- `npm run check:client` *(fails: Property 'env' does not exist on type 'ImportMeta')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7bcc3512c832a9de9580747853f6c