### PR TITLE
Unify status terminology

### DIFF
--- a/client/src/pages/admin/deals/add.tsx
+++ b/client/src/pages/admin/deals/add.tsx
@@ -155,12 +155,12 @@ export default function AddDealPage() {
   const [previewTerms, setPreviewTerms] = useState("");
   const [manualVendorEntry, setManualVendorEntry] = useState(false);
 
-  // Fetch all vendors (both approved and pending for admin)
+  // Fetch all vendors (both verified and pending for admin)
   const { data: vendors = [], isLoading: vendorsLoading } = useQuery({
     queryKey: ['admin', 'vendors'],
     queryFn: async () => {
       try {
-        // Try to get all vendors - both approved and pending
+        // Try to get all vendors - both verified and pending
         const response = await apiRequest('/api/v1/admin/businesses');
         
         // Handle both array and object response formats
@@ -172,9 +172,8 @@ export default function AddDealPage() {
           vendorsArray = Object.values(response);
         }
         
-        // Filter for approved and pending businesses 
+        // Filter for verified and pending businesses 
         return vendorsArray.filter(vendor => 
-          vendor.verificationStatus === 'approved' || 
           vendor.verificationStatus === 'verified' || 
           vendor.verificationStatus === 'pending'
         );

--- a/client/src/pages/admin/index.tsx
+++ b/client/src/pages/admin/index.tsx
@@ -39,7 +39,7 @@ type StatValue = string | number;
 
 interface DashboardStats {
   pendingVendors: StatValue;
-  approvedVendors: StatValue;
+  verifiedVendors: StatValue;
   rejectedVendors: StatValue;
   pendingDeals: StatValue;
   activeDeals: StatValue;
@@ -110,7 +110,7 @@ const StatCard = ({
 interface ActivityItem {
   id: number;
   type: "vendor_application" | "deal_submission" | "user_registration" | "deal_redemption";
-  status: "pending" | "approved" | "rejected" | "completed";
+  status: "pending" | "verified" | "rejected" | "completed";
   title: string;
   description: string;
   timestamp: string;
@@ -121,7 +121,7 @@ const ActivityCard = ({ activity }: { activity: ActivityItem }) => {
     switch (activity.status) {
       case "pending":
         return <Clock className="h-4 w-4 text-yellow-500" />;
-      case "approved":
+      case "verified":
         return <CheckCircle className="h-4 w-4 text-green-500" />;
       case "rejected":
         return <XCircle className="h-4 w-4 text-red-500" />;
@@ -309,7 +309,7 @@ const AdminDashboardPage = () => {
     recentActivity?: Array<{
       id: number;
       type: "vendor_application" | "deal_submission" | "user_registration" | "deal_redemption";
-      status: "pending" | "approved" | "rejected" | "completed";
+      status: "pending" | "verified" | "rejected" | "completed";
       title: string;
       description: string;
       timestamp: string;
@@ -353,7 +353,7 @@ const AdminDashboardPage = () => {
     // Initialize with default values and error states
     const defaultStats: DashboardStats = {
       pendingVendors: 'N/A',
-      approvedVendors: 'N/A', 
+      verifiedVendors: 'N/A', 
       rejectedVendors: 'N/A',
       pendingDeals: 'N/A',
       activeDeals: 'N/A',
@@ -373,7 +373,7 @@ const AdminDashboardPage = () => {
     // Initialize with numeric values
     const numericStats: DashboardStats = {
       pendingVendors: 0,
-      approvedVendors: 0, 
+      verifiedVendors: 0, 
       rejectedVendors: 0,
       pendingDeals: 0,
       activeDeals: 0,
@@ -400,7 +400,7 @@ const AdminDashboardPage = () => {
         } else {
           console.error("Vendors data is not an array or object:", vendorsData);
           numericStats.pendingVendors = 'Error';
-          numericStats.approvedVendors = 'Error';
+          numericStats.verifiedVendors = 'Error';
           numericStats.rejectedVendors = 'Error';
           return numericStats;
         }
@@ -411,8 +411,7 @@ const AdminDashboardPage = () => {
           vendor.verificationStatus === 'pending'
         );
         
-        const approvedVendors = vendorsArray.filter((vendor: any) => 
-          vendor.verificationStatus === 'approved' || 
+        const verifiedVendors = vendorsArray.filter((vendor: any) => 
           vendor.verificationStatus === 'verified'
         );
         
@@ -422,19 +421,19 @@ const AdminDashboardPage = () => {
         
         // Update all vendor-related stats
         numericStats.pendingVendors = pendingVendors.length;
-        numericStats.approvedVendors = approvedVendors.length;
+        numericStats.verifiedVendors = verifiedVendors.length;
         numericStats.rejectedVendors = rejectedVendors.length;
         
         // Log vendor counts for debugging
         console.log(`Dashboard: Found ${pendingVendors.length} pending vendors`);
-        console.log(`Dashboard: Found ${approvedVendors.length} approved vendors (including ${
-          approvedVendors.filter(v => v.verificationStatus === 'verified').length
+        console.log(`Dashboard: Found ${verifiedVendors.length} verified vendors (including ${
+          verifiedVendors.filter(v => v.verificationStatus === 'verified').length
         } verified vendors)`);
         console.log(`Dashboard: Found ${rejectedVendors.length} rejected vendors`);
       } catch (error) {
         console.error("Error processing vendors data:", error);
         numericStats.pendingVendors = 'Error';
-        numericStats.approvedVendors = 'Error';
+        numericStats.verifiedVendors = 'Error';
         numericStats.rejectedVendors = 'Error';
       }
     }
@@ -466,7 +465,7 @@ const AdminDashboardPage = () => {
         ).length;
         
         numericStats.activeDeals = dealsArray.filter((deal: any) => 
-          deal.status === 'approved' && new Date(deal.endDate) > new Date()
+          deal.status === 'verified' && new Date(deal.endDate) > new Date()
         ).length;
         
         numericStats.rejectedDeals = dealsArray.filter((deal: any) => 
@@ -474,7 +473,7 @@ const AdminDashboardPage = () => {
         ).length;
         
         numericStats.expiredDeals = dealsArray.filter((deal: any) => 
-          deal.status === 'approved' && new Date(deal.endDate) <= new Date()
+          deal.status === 'verified' && new Date(deal.endDate) <= new Date()
         ).length;
         
         // Log deal counts for debugging
@@ -605,8 +604,8 @@ const AdminDashboardPage = () => {
     if (isPositiveNumber(stats.pendingDeals)) {
       newAlerts.push({
         id: 2,
-        title: "Deal Approval Backlog",
-        description: `${stats.pendingDeals} deals are pending approval`,
+        title: "Deal Verification Backlog",
+        description: `${stats.pendingDeals} deals are pending verification`,
         priority: isGreaterThan(stats.pendingDeals, 5) ? "high" : "medium"
       });
     }
@@ -682,7 +681,7 @@ const AdminDashboardPage = () => {
           title="Pending Vendors"
           value={stats.pendingVendors}
           icon={<Store className="h-4 w-4" />}
-          description="Vendors awaiting approval"
+          description="Vendors awaiting verification"
           isLoading={isLoadingVendors}
           action={{
             label: "View All",
@@ -690,14 +689,14 @@ const AdminDashboardPage = () => {
           }}
         />
         <StatCard
-          title="Approved Vendors"
-          value={stats.approvedVendors}
+          title="Verified Vendors"
+          value={stats.verifiedVendors}
           icon={<CheckCircle className="h-4 w-4" />}
           description="Active vendors"
           isLoading={isLoadingVendors}
           action={{
             label: "View All",
-            onClick: () => window.location.href = "/admin/vendors?status=approved"
+            onClick: () => window.location.href = "/admin/vendors?status=verified"
           }}
         />
         <StatCard

--- a/client/src/pages/admin/vendors/[id].tsx
+++ b/client/src/pages/admin/vendors/[id].tsx
@@ -62,7 +62,7 @@ interface Business {
   businessName: string;
   businessCategory: string;
   appliedDate: string;
-  status: "new" | "in_review" | "approved" | "rejected";
+  status: "new" | "in_review" | "verified" | "rejected";
   verificationStatus: string;
   verificationFeedback?: string;
   email: string;
@@ -94,9 +94,9 @@ export default function VendorDetailPage() {
   const [, navigate] = useLocation();
   const [business, setBusiness] = useState<Business | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [approvalStatus, setApprovalStatus] = useState<string>("pending");
+  const [verificationStatus, setVerificationStatus] = useState<string>("pending");
   const [feedbackText, setFeedbackText] = useState<string>("");
-  const [isApprovalDialogOpen, setIsApprovalDialogOpen] = useState(false);
+  const [isVerificationDialogOpen, setIsVerificationDialogOpen] = useState(false);
   const [isRejectionDialogOpen, setIsRejectionDialogOpen] = useState(false);
   const [selectedDocumentId, setSelectedDocumentId] = useState<number | null>(null);
   const { toast } = useToast();
@@ -161,7 +161,7 @@ export default function VendorDetailPage() {
         };
         
         setBusiness(businessData);
-        setApprovalStatus(businessData.verificationStatus || "pending");
+        setVerificationStatus(businessData.verificationStatus || "pending");
       } else {
         // Fall back to mock data if API fails
         const mockBusiness: Business = {
@@ -208,7 +208,7 @@ export default function VendorDetailPage() {
         };
         
         setBusiness(mockBusiness);
-        setApprovalStatus(mockBusiness.verificationStatus);
+        setVerificationStatus(mockBusiness.verificationStatus);
       }
     } catch (error) {
       console.error("Error fetching business data:", error);
@@ -236,7 +236,7 @@ export default function VendorDetailPage() {
       
       toast({
         title: "Success",
-        description: `Vendor ${status === "approved" ? "approved" : "rejected"} successfully`
+        description: `Vendor ${status === "verified" ? "verified" : "rejected"} successfully`
       });
 
       // Update local state
@@ -245,10 +245,10 @@ export default function VendorDetailPage() {
         verificationStatus: status,
         verificationFeedback: feedbackText
       });
-      setApprovalStatus(status);
+      setVerificationStatus(status);
       
       // Close dialogs
-      setIsApprovalDialogOpen(false);
+      setIsVerificationDialogOpen(false);
       setIsRejectionDialogOpen(false);
       
       // Clear feedback text
@@ -267,7 +267,7 @@ export default function VendorDetailPage() {
     switch (status) {
       case "pending":
         return "text-yellow-600 bg-yellow-50 border-yellow-200";
-      case "approved":
+      case "verified":
         return "text-green-600 bg-green-50 border-green-200";
       case "verified":
         return "text-green-600 bg-green-50 border-green-200";
@@ -282,7 +282,7 @@ export default function VendorDetailPage() {
     switch (status) {
       case "pending":
         return <Clock className="h-4 w-4 mr-1" />;
-      case "approved":
+      case "verified":
         return <CheckCircle className="h-4 w-4 mr-1" />;
       case "verified":
         return <ShieldCheck className="h-4 w-4 mr-1" />;
@@ -344,12 +344,12 @@ export default function VendorDetailPage() {
           {business.verificationStatus === "pending" || business.verificationStatus === "rejected" ? (
             <Button 
               className="bg-green-600 hover:bg-green-700"
-              onClick={() => setIsApprovalDialogOpen(true)}
+              onClick={() => setIsVerificationDialogOpen(true)}
             >
-              <CheckCircle className="mr-2 h-4 w-4" /> Approve
+              <CheckCircle className="mr-2 h-4 w-4" /> Verify
             </Button>
           ) : null}
-          {business.verificationStatus === "pending" || business.verificationStatus === "approved" ? (
+          {business.verificationStatus === "pending" || business.verificationStatus === "verified" ? (
             <Button 
               variant="destructive"
               onClick={() => setIsRejectionDialogOpen(true)}
@@ -437,11 +437,11 @@ export default function VendorDetailPage() {
         <Card>
           <CardHeader>
             <CardTitle>Verification Status</CardTitle>
-            <CardDescription>Current approval status</CardDescription>
+            <CardDescription>Current verification status</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex flex-col items-center justify-center py-4">
-              {business.verificationStatus === "approved" ? (
+              {business.verificationStatus === "verified" ? (
                 <div className="p-4 bg-green-50 rounded-full mb-4">
                   <CheckCircle className="h-10 w-10 text-green-600" />
                 </div>
@@ -455,14 +455,14 @@ export default function VendorDetailPage() {
                 </div>
               )}
               <h3 className="text-lg font-semibold mb-1">
-                {business.verificationStatus === "approved" 
-                  ? "Approved" 
+                {business.verificationStatus === "verified" 
+                  ? "Verified" 
                   : business.verificationStatus === "rejected"
                   ? "Rejected"
-                  : "Pending Approval"}
+                  : "Pending Verification"}
               </h3>
               <p className="text-sm text-muted-foreground text-center">
-                {business.verificationStatus === "approved"
+                {business.verificationStatus === "verified"
                   ? "This vendor has been verified and can create deals."
                   : business.verificationStatus === "rejected"
                   ? "This vendor has been rejected and cannot create deals."
@@ -487,12 +487,12 @@ export default function VendorDetailPage() {
                   <Button 
                     variant="outline" 
                     className="w-full justify-start text-green-600 hover:text-green-700 hover:bg-green-50 border-green-200"
-                    onClick={() => setIsApprovalDialogOpen(true)}
+                    onClick={() => setIsVerificationDialogOpen(true)}
                   >
-                    <CheckCircle className="h-4 w-4 mr-2" /> Approve Vendor
+                    <CheckCircle className="h-4 w-4 mr-2" /> Verify Vendor
                   </Button>
                 ) : null}
-                {business.verificationStatus === "pending" || business.verificationStatus === "approved" ? (
+                {business.verificationStatus === "pending" || business.verificationStatus === "verified" ? (
                   <Button 
                     variant="outline" 
                     className="w-full justify-start text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200"
@@ -587,13 +587,13 @@ export default function VendorDetailPage() {
         </TabsContent>
       </Tabs>
 
-      {/* Approve Dialog */}
-      <Dialog open={isApprovalDialogOpen} onOpenChange={setIsApprovalDialogOpen}>
+      {/* Verify Dialog */}
+      <Dialog open={isVerificationDialogOpen} onOpenChange={setIsVerificationDialogOpen}>
         <DialogContent className="sm:max-w-[500px]">
           <DialogHeader>
-            <DialogTitle>Approve Vendor</DialogTitle>
+            <DialogTitle>Verify Vendor</DialogTitle>
             <DialogDescription>
-              Are you sure you want to approve this vendor? They will be able to create and publish deals.
+              Are you sure you want to verify this vendor? They will be able to create and publish deals.
             </DialogDescription>
           </DialogHeader>
           <div className="flex items-center justify-center py-6">
@@ -603,7 +603,7 @@ export default function VendorDetailPage() {
           </div>
           <div className="space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Approval Feedback (Optional)</label>
+              <label className="text-sm font-medium">Verification Feedback (Optional)</label>
               <Textarea 
                 placeholder="Enter any feedback for the vendor..."
                 value={feedbackText}
@@ -612,12 +612,12 @@ export default function VendorDetailPage() {
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setIsApprovalDialogOpen(false)}>Cancel</Button>
+            <Button variant="outline" onClick={() => setIsVerificationDialogOpen(false)}>Cancel</Button>
             <Button 
               className="bg-green-600 hover:bg-green-700" 
-              onClick={() => handleUpdateVerificationStatus("approved")}
+              onClick={() => handleUpdateVerificationStatus("verified")}
             >
-              Approve Vendor
+              Verify Vendor
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/client/src/pages/admin/vendors/index.tsx
+++ b/client/src/pages/admin/vendors/index.tsx
@@ -76,7 +76,7 @@ interface Business {
   businessName: string;
   businessCategory: string;
   appliedDate: string;
-  status: "new" | "in_review" | "approved" | "rejected";
+  status: "new" | "in_review" | "verified" | "rejected";
   verificationStatus: string;
   verificationFeedback?: string;
   email: string;
@@ -96,7 +96,7 @@ export default function VendorsPage() {
   const [filteredBusinesses, setFilteredBusinesses] = useState<Business[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [pendingCount, setPendingCount] = useState(0);
-  const [approvedCount, setApprovedCount] = useState(0);
+  const [verifiedCount, setVerifiedCount] = useState(0);
   const [rejectedCount, setRejectedCount] = useState(0);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [businessToDelete, setBusinessToDelete] = useState<Business | null>(null);
@@ -398,10 +398,9 @@ export default function VendorsPage() {
 
     // Apply status filter
     if (statusFilter !== "all") {
-      if (statusFilter === "approved") {
-        // When "approved" filter is selected, include both "approved" and "verified" statuses
+      if (statusFilter === "verified") {
+        // When "verified" filter is selected, include only "verified" status
         filtered = filtered.filter(business => 
-          business.verificationStatus === "approved" || 
           business.verificationStatus === "verified"
         );
       } else {
@@ -440,9 +439,9 @@ export default function VendorsPage() {
 
     // Count by status
     setPendingCount(businesses.filter((b: Business) => b.verificationStatus === "pending").length);
-    setApprovedCount(
+    setVerifiedCount(
       businesses.filter(
-        (b: Business) => b.verificationStatus === "approved" || b.verificationStatus === "verified"
+        (b: Business) => b.verificationStatus === "verified"
       ).length
     );
     setRejectedCount(businesses.filter((b: Business) => b.verificationStatus === "rejected").length);
@@ -461,9 +460,9 @@ export default function VendorsPage() {
     switch (status) {
       case "pending":
         return <Badge variant="outline" className="flex items-center gap-1 font-normal text-yellow-600 border-yellow-300 bg-yellow-50"><Clock className="h-3 w-3" /> Pending</Badge>;
-      case "approved":
-      case "verified":  // Treat "verified" same as "approved"
-        return <Badge variant="outline" className="flex items-center gap-1 font-normal text-green-600 border-green-300 bg-green-50"><CheckCircle className="h-3 w-3" /> Approved</Badge>;
+      case "verified":
+      case "verified":  // Treat "verified" same as "verified"
+        return <Badge variant="outline" className="flex items-center gap-1 font-normal text-green-600 border-green-300 bg-green-50"><CheckCircle className="h-3 w-3" /> Verified</Badge>;
       case "rejected":
         return <Badge variant="outline" className="flex items-center gap-1 font-normal text-red-600 border-red-300 bg-red-50"><XCircle className="h-3 w-3" /> Rejected</Badge>;
       case "review":
@@ -489,8 +488,8 @@ export default function VendorsPage() {
       // Update counts
       if (businessToDelete.verificationStatus === 'pending') {
         setPendingCount(prev => prev - 1);
-      } else if (businessToDelete.verificationStatus === 'approved' || businessToDelete.verificationStatus === 'verified') {
-        setApprovedCount(prev => prev - 1);
+      } else if (businessToDelete.verificationStatus === 'verified' || businessToDelete.verificationStatus === 'verified') {
+        setVerifiedCount(prev => prev - 1);
       } else if (businessToDelete.verificationStatus === 'rejected') {
         setRejectedCount(prev => prev - 1);
       }
@@ -547,7 +546,7 @@ export default function VendorsPage() {
         </Card>
         <Card>
           <CardHeader className="py-4">
-            <CardTitle className="text-base text-muted-foreground">Approved</CardTitle>
+            <CardTitle className="text-base text-muted-foreground">Verified</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
@@ -557,8 +556,8 @@ export default function VendorsPage() {
               </div>
             ) : (
               <>
-                <div className="text-2xl font-bold">{approvedCount || 'N/A'}</div>
-                <p className="text-xs text-muted-foreground mt-1">Active vendors (approved & verified)</p>
+                <div className="text-2xl font-bold">{verifiedCount || 'N/A'}</div>
+                <p className="text-xs text-muted-foreground mt-1">Active vendors (verified)</p>
               </>
             )}
           </CardContent>
@@ -601,12 +600,12 @@ export default function VendorsPage() {
             <Clock className="mr-2 h-3 w-3" /> Pending
           </Button>
           <Button 
-            variant={statusFilter === "approved" ? "default" : "outline"} 
+            variant={statusFilter === "verified" ? "default" : "outline"} 
             size="sm"
-            onClick={() => setStatusFilter("approved")}
-            className={statusFilter === "approved" ? "" : "text-green-600 border-green-300 hover:bg-green-50"}
+            onClick={() => setStatusFilter("verified")}
+            className={statusFilter === "verified" ? "" : "text-green-600 border-green-300 hover:bg-green-50"}
           >
-            <CheckCircle className="mr-2 h-3 w-3" /> Approved
+            <CheckCircle className="mr-2 h-3 w-3" /> Verified
           </Button>
           <Button 
             variant={statusFilter === "rejected" ? "default" : "outline"} 

--- a/client/src/pages/vendor/deals/create.tsx
+++ b/client/src/pages/vendor/deals/create.tsx
@@ -559,7 +559,7 @@ export default function CreateDealPage() {
       if (startDate < tomorrow) {
         form.setError("startDate", {
           type: "manual",
-          message: "Please select a start date at least 24 hours in the future to allow for approval."
+          message: "Please select a start date at least 24 hours in the future to allow for verification."
         });
       }
     }
@@ -808,7 +808,7 @@ export default function CreateDealPage() {
       
       toast({
         title: "Deal created successfully",
-        description: "Your deal has been submitted for approval",
+        description: "Your deal has been submitted for verification",
         variant: "default"
       });
       
@@ -1151,7 +1151,7 @@ export default function CreateDealPage() {
                             if (date < tomorrow) {
                               form.setError("startDate", {
                                 type: "manual",
-                                message: "Please select a start date at least 24 hours in the future to allow for approval."
+                                message: "Please select a start date at least 24 hours in the future to allow for verification."
                               });
                             } else {
                               form.clearErrors("startDate");
@@ -1202,7 +1202,7 @@ export default function CreateDealPage() {
               <Alert className="bg-amber-50 border-amber-200 mt-2">
                 <AlertTriangle className="h-4 w-4 text-amber-500" />
                 <AlertDescription className="text-amber-700 text-sm">
-                  Please allow up to 24 hours for deal approval before your deal goes live.
+                  Please allow up to 24 hours for deal verification before your deal goes live.
                 </AlertDescription>
               </Alert>
               
@@ -1414,7 +1414,7 @@ export default function CreateDealPage() {
               <Alert className="bg-yellow-50 border-yellow-200">
                 <Info className="h-4 w-4 text-yellow-500" />
                 <AlertDescription className="text-yellow-700">
-                  Please review your deal information carefully. All deals require admin approval before becoming active.
+                  Please review your deal information carefully. All deals require admin verification before becoming active.
                 </AlertDescription>
               </Alert>
               
@@ -1668,7 +1668,7 @@ export default function CreateDealPage() {
             {submitting ? 'Processing...' : 
              currentStep < steps.length - 1 ? 'Continue' : 
              csrfLoading ? 'Securing Connection...' : 
-             'Submit Deal for Approval'}
+             'Submit Deal for Verification'}
             {!submitting && currentStep < steps.length - 1 && <ChevronRight className="ml-2 h-4 w-4" />}
           </Button>
         </CardFooter>

--- a/client/src/pages/vendor/deals/edit/[id].tsx
+++ b/client/src/pages/vendor/deals/edit/[id].tsx
@@ -123,7 +123,7 @@ export default function EditDealPage() {
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   const [dealData, setDealData] = useState<any>(null);
-  const [showApprovalWarning, setShowApprovalWarning] = useState(false);
+  const [showVerificationWarning, setShowVerificationWarning] = useState(false);
   
   // Initialize form
   const form = useForm<z.infer<typeof dealFormSchema>>({
@@ -193,9 +193,9 @@ export default function EditDealPage() {
             status: data.status || 'draft',
           });
           
-          // Show approval warning for deals in approval process
-          if (['pending', 'approved', 'active'].includes(data.status)) {
-            setShowApprovalWarning(true);
+          // Show verification warning for deals in verification process
+          if (['pending', 'verified'].includes(data.status)) {
+            setShowVerificationWarning(true);
           }
         } else {
           toast({
@@ -400,8 +400,7 @@ export default function EditDealPage() {
     const statusMap: Record<string, string> = {
       'draft': 'bg-gray-100 text-gray-700 border-gray-200',
       'pending': 'bg-yellow-100 text-yellow-800 border-yellow-200',
-      'active': 'bg-green-100 text-green-800 border-green-200',
-      'approved': 'bg-green-100 text-green-800 border-green-200',
+      'verified': 'bg-green-100 text-green-800 border-green-200',
       'rejected': 'bg-red-100 text-red-800 border-red-200',
       'pending_revision': 'bg-orange-100 text-orange-800 border-orange-200',
       'expired': 'bg-gray-100 text-gray-700 border-gray-200'
@@ -414,9 +413,8 @@ export default function EditDealPage() {
   const getStatusText = () => {
     const statusTextMap: Record<string, string> = {
       'draft': 'Draft',
-      'pending': 'Pending Approval',
-      'active': 'Active',
-      'approved': 'Approved',
+      'pending': 'Pending Verification',
+      'verified': 'Verified',
       'rejected': 'Rejected',
       'pending_revision': 'Revision Requested',
       'expired': 'Expired'
@@ -482,7 +480,7 @@ export default function EditDealPage() {
         <Alert className="mb-6 border-yellow-200 bg-yellow-50">
           <Info className="h-4 w-4 text-yellow-700" />
           <AlertDescription className="text-yellow-700">
-            <p>This deal is currently under review by our team. Any changes you make will reset the approval process.</p>
+            <p>This deal is currently under review by our team. Any changes you make will reset the verification process.</p>
           </AlertDescription>
         </Alert>
       )}
@@ -504,25 +502,25 @@ export default function EditDealPage() {
           <AlertDescription className="text-orange-700">
             <p className="font-medium">Our team has requested the following revisions:</p>
             <p className="mt-1">{dealData.revisionNotes}</p>
-            <p className="mt-2">Please update your deal and resubmit for approval.</p>
+            <p className="mt-2">Please update your deal and resubmit for verification.</p>
           </AlertDescription>
         </Alert>
       )}
       
-      {dealStatus === 'approved' && dealData && (
+      {dealStatus === 'verified' && dealData && (
         <Alert className="mb-6 border-green-200 bg-green-50">
           <Info className="h-4 w-4 text-green-700" />
           <AlertDescription className="text-green-700">
-            <p>This deal has been approved. Any significant changes will require re-approval.</p>
+            <p>This deal has been verified. Any significant changes will require re-verification.</p>
           </AlertDescription>
         </Alert>
       )}
       
-      {showApprovalWarning && (
+      {showVerificationWarning && (
         <Alert className="mb-6 border-blue-200 bg-blue-50">
           <Info className="h-4 w-4 text-blue-700" />
           <AlertDescription className="text-blue-700">
-            <p>Making changes to this deal will require it to go through the approval process again. Your changes will be saved as a draft until approved.</p>
+            <p>Making changes to this deal will require it to go through the verification process again. Your changes will be saved as a draft until verified.</p>
           </AlertDescription>
         </Alert>
       )}

--- a/client/src/pages/vendor/deals/manage/[id].tsx
+++ b/client/src/pages/vendor/deals/manage/[id].tsx
@@ -129,8 +129,7 @@ export default function ManageDealPage() {
     const statusMap: Record<string, string> = {
       'draft': 'bg-gray-100 text-gray-700 border-gray-200',
       'pending': 'bg-yellow-100 text-yellow-800 border-yellow-200',
-      'active': 'bg-green-100 text-green-800 border-green-200',
-      'approved': 'bg-green-100 text-green-800 border-green-200',
+      'verified': 'bg-green-100 text-green-800 border-green-200',
       'rejected': 'bg-red-100 text-red-800 border-red-200',
       'pending_revision': 'bg-orange-100 text-orange-800 border-orange-200',
       'expired': 'bg-gray-100 text-gray-700 border-gray-200'
@@ -145,9 +144,8 @@ export default function ManageDealPage() {
     
     const statusTextMap: Record<string, string> = {
       'draft': 'Draft',
-      'pending': 'Pending Approval',
-      'active': 'Active',
-      'approved': 'Approved',
+      'pending': 'Pending Verification',
+        'verified': 'Verified',
       'rejected': 'Rejected',
       'pending_revision': 'Revision Requested',
       'expired': 'Expired'
@@ -182,7 +180,7 @@ export default function ManageDealPage() {
   // Check if deal is active
   const isDealActive = () => {
     if (!dealData) return false;
-    return dealData.status === 'active' || dealData.status === 'approved';
+    return dealData.status === 'verified';
   };
   
   // Check if deal is expired

--- a/client/src/pages/vendor/index.tsx
+++ b/client/src/pages/vendor/index.tsx
@@ -31,13 +31,11 @@ import {
 
 // Define status colors for consistent use across components
 const statusColors: Record<string, string> = {
-  approved: 'bg-green-100 text-green-800 border-green-200',
   verified: 'bg-green-100 text-green-800 border-green-200',
   pending: 'bg-yellow-100 text-yellow-800 border-yellow-200',
   rejected: 'bg-red-100 text-red-800 border-red-200',
   draft: 'bg-gray-100 text-gray-700 border-gray-200',
   expired: 'bg-gray-100 text-gray-700 border-gray-200',
-  active: 'bg-blue-100 text-blue-800 border-blue-200'
 };
 
 export default function VendorDashboard() {
@@ -111,7 +109,7 @@ export default function VendorDashboard() {
               
               // Calculate stats
               const activeDeals = dealsArray.filter((deal: any) => 
-                new Date(deal.endDate) >= new Date() && deal.status === 'approved'
+                new Date(deal.endDate) >= new Date() && deal.status === 'verified'
               ).length;
               
               // Sum up counts
@@ -156,7 +154,7 @@ export default function VendorDashboard() {
     );
   }
 
-  const isBusinessApproved = business?.verificationStatus === 'verified';
+  const isBusinessVerified = business?.verificationStatus === 'verified';
   
   // Count active filters for badge display
   const countActiveFilters = (): number => {
@@ -226,7 +224,7 @@ export default function VendorDashboard() {
         }
         
         // Only include deals that match the selected status filters
-        return (filters.status.active && isTimeActive && (deal.status === 'approved' || deal.status === 'active')) ||
+        return (filters.status.active && isTimeActive && (deal.status === 'verified')) ||
                (filters.status.upcoming && isUpcoming) ||
                (filters.status.expired && isExpired) ||
                (filters.status.pending && deal.status === 'pending') ||
@@ -349,7 +347,7 @@ export default function VendorDashboard() {
         onOpenChange={setRedemptionDialogOpen}
       />
       
-      {/* Welcome and approval status banner */}
+      {/* Welcome and verification status banner */}
       <header className="mb-6 sm:mb-8">
         <div className="flex-responsive justify-between sm:items-start mb-4 sm:mb-2 gap-3 sm:gap-0">
           <div>
@@ -358,20 +356,20 @@ export default function VendorDashboard() {
           </div>
           <Button 
             className="bg-[#00796B] hover:bg-[#004D40] sm:mt-0 w-full sm:w-auto"
-            disabled={!isBusinessApproved}
+            disabled={!isBusinessVerified}
             onClick={handleCreateDeal}
           >
             <PlusCircle className="mr-2 h-4 w-4" /> Create Deal
           </Button>
         </div>
 
-        {/* Approval status banner */}
-        {!isBusinessApproved && (
+        {/* Verification status banner */}
+        {!isBusinessVerified && (
           <Alert className="mt-4 border-yellow-200 bg-yellow-50">
             <AlertCircle className="h-5 w-5 text-yellow-700" />
-            <AlertTitle className="text-yellow-800">Approval Pending</AlertTitle>
+            <AlertTitle className="text-yellow-800">Verification Pending</AlertTitle>
             <AlertDescription className="text-yellow-700">
-              Your business profile is currently under review. You'll be able to create deals once approved.
+              Your business profile is currently under review. You'll be able to create deals once verified.
               <div className="mt-2 flex items-center">
                 <span className="text-sm mr-2">Estimated time: 1-2 business days</span>
                 <Button 
@@ -418,7 +416,7 @@ export default function VendorDashboard() {
         />
       </div>
 
-      {!isBusinessApproved && (
+      {!isBusinessVerified && (
         <VerificationRequirements business={business} />
       )}
 
@@ -478,7 +476,7 @@ export default function VendorDashboard() {
               )}
               <Button 
                 className="bg-[#00796B] hover:bg-[#004D40] w-full sm:w-auto"
-                disabled={!isBusinessApproved}
+                disabled={!isBusinessVerified}
                 onClick={handleCreateDeal}
                 size="sm"
               >
@@ -493,7 +491,7 @@ export default function VendorDashboard() {
               description="Create your first deal to start attracting customers"
               actionText="Create Deal"
               onClick={handleCreateDeal}
-              disabled={!isBusinessApproved}
+              disabled={!isBusinessVerified}
             />
           ) : (
             <div className="card-grid">
@@ -535,7 +533,7 @@ export default function VendorDashboard() {
                         const isExpired = new Date(deal.endDate) < now;
                         
                         if (value === 'active') {
-                          return isTimeActive && (deal.status === 'approved' || deal.status === 'active');
+                          return isTimeActive && (deal.status === 'verified');
                         } else if (value === 'upcoming') {
                           return isUpcoming;
                         } else if (value === 'expired') {
@@ -569,11 +567,11 @@ export default function VendorDashboard() {
                 // Same status determination code as in your table rows
                 if (deal.status === 'pending') {
                   statusClass = 'bg-yellow-100 text-yellow-800';
-                  statusText = 'Pending Approval';
-                } else if (deal.status === 'approved' && new Date(deal.endDate) >= new Date() && new Date(deal.startDate) <= new Date()) {
+                  statusText = 'Pending Verification';
+                } else if (deal.status === 'verified' && new Date(deal.endDate) >= new Date() && new Date(deal.startDate) <= new Date()) {
                   statusClass = 'bg-green-100 text-green-800';
                   statusText = 'Active';
-                } else if (deal.status === 'approved' && new Date(deal.startDate) > new Date()) {
+                } else if (deal.status === 'verified' && new Date(deal.startDate) > new Date()) {
                   statusClass = 'bg-blue-100 text-blue-800';
                   statusText = 'Upcoming';
                 } else if (new Date(deal.endDate) < new Date() || deal.status === 'expired') {
@@ -704,9 +702,9 @@ export default function VendorDashboard() {
                   </thead>
                   <tbody className="divide-y divide-gray-200">
                   {deals.length > 0 ? deals.map((deal: any) => {
-                    // Deal approval status (from the backend)
+                    // Deal verification status (from the backend)
                     const isPending = deal.status === 'pending';
-                    const isApproved = deal.status === 'approved';
+                    const isVerified = deal.status === 'verified';
                     
                     // Deal time-based status - with safe date handling
                     let isTimeActive = false, isUpcoming = false, isExpired = false;
@@ -729,11 +727,11 @@ export default function VendorDashboard() {
                     
                     if (isPending) {
                       statusClass = 'bg-yellow-100 text-yellow-800';
-                      statusText = 'Pending Approval';
-                    } else if (isApproved && isTimeActive) {
+                      statusText = 'Pending Verification';
+                    } else if (isVerified && isTimeActive) {
                       statusClass = 'bg-green-100 text-green-800';
                       statusText = 'Active';
-                    } else if (isApproved && isUpcoming) {
+                    } else if (isVerified && isUpcoming) {
                       statusClass = 'bg-blue-100 text-blue-800';
                       statusText = 'Upcoming';
                     } else if (isExpired || deal.status === 'expired') {
@@ -1131,15 +1129,15 @@ function DealCard({ deal }: { deal: any }) {
   const isUpcoming = new Date(deal.startDate) > new Date();
   const isExpired = new Date(deal.endDate) < new Date();
   
-  // Status logic - include pending and approval states
+  // Status logic - include pending and verification states
   let status = deal.status || 'draft';
   
-  // If deal is in 'pending' approval state
+  // If deal is in 'pending' verification state
   const isPending = status === 'pending';
   
-  // Show appropriate status label based on approval state and date
+  // Show appropriate status label based on verification state and date
   let statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
-  if (status === 'approved') {
+  if (status === 'verified') {
     if (isExpired) statusLabel = 'Expired';
     else if (isUpcoming) statusLabel = 'Upcoming';
     else statusLabel = 'Active';
@@ -1174,7 +1172,7 @@ function DealCard({ deal }: { deal: any }) {
             <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
               <div className="bg-white/90 px-3 sm:px-4 py-1.5 sm:py-2 rounded-md flex items-center">
                 <Clock className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-yellow-600 mr-1.5 sm:mr-2" />
-                <span className="text-xs sm:text-sm font-medium">Awaiting Approval</span>
+                <span className="text-xs sm:text-sm font-medium">Awaiting Verification</span>
               </div>
             </div>
           )}
@@ -1281,7 +1279,7 @@ function VerificationRequirements({ business }: { business: any }) {
       <CardFooter className="border-t px-4 sm:px-6 pt-3 sm:pt-4 pb-4 sm:pb-5">
         <div className="flex items-start sm:items-center text-xs text-gray-500">
           <Clock className="w-3.5 h-3.5 sm:w-4 sm:h-4 mr-1.5 sm:mr-2 mt-0.5 sm:mt-0 flex-shrink-0" />
-          <span>Estimated approval: 1-2 business days after all documents are submitted</span>
+          <span>Estimated verification: 1-2 business days after all documents are submitted</span>
         </div>
       </CardFooter>
     </Card>

--- a/server/routes/deal.routes.ts
+++ b/server/routes/deal.routes.ts
@@ -425,7 +425,7 @@ export function dealRoutes(app: Express): void {
         }
         
         // Ensure the business is verified
-        if (business.verificationStatus !== "verified" && business.verificationStatus !== "approved") {
+        if (business.verificationStatus !== "verified") {
           return res.status(403).json({ 
             message: "Your business must be verified before creating deals",
             verificationStatus: business.verificationStatus 
@@ -439,7 +439,7 @@ export function dealRoutes(app: Express): void {
         const dealData = {
           ...processedBody,
           businessId: business.id,
-          status: "pending" // All deals start as pending until approved
+          status: "pending" // All deals start as pending until verified
         };
         
         const deal = await storage.createDeal(dealData);
@@ -471,8 +471,8 @@ export function dealRoutes(app: Express): void {
           return res.status(404).json({ message: "Business not found for this user" });
         }
         
-        // Ensure the business is verified (accept both "verified" and "approved" status)
-        if (business.verificationStatus !== "verified" && business.verificationStatus !== "approved") {
+        // Ensure the business is verified 
+        if (business.verificationStatus !== "verified") {
           return res.status(403).json({ 
             message: "Your business must be verified before creating deals",
             verificationStatus: business.verificationStatus 
@@ -486,7 +486,7 @@ export function dealRoutes(app: Express): void {
         const dealData = {
           ...processedBody,
           businessId: business.id,
-          status: "pending" // All deals start as pending until approved
+          status: "pending" // All deals start as pending until verified
         };
         
         const deal = await storage.createDeal(dealData);
@@ -661,8 +661,8 @@ export function dealRoutes(app: Express): void {
     }
   );
 
-  // Admin routes for approving/rejecting deals
-  app.patch('/api/v1/admin/deals/:id/approve', 
+  // Admin routes for verifying/rejecting deals
+  app.patch('/api/v1/admin/deals/:id/verify', 
     authenticate, 
     authorize(["admin"]),
     async (req: Request, res: Response) => {
@@ -676,12 +676,12 @@ export function dealRoutes(app: Express): void {
           return res.status(404).json({ message: "Deal not found" });
         }
         
-        // Update the deal status to approved
-        const updatedDeal = await storage.updateDeal(dealId, { status: "approved" });
+        // Update the deal status to verified
+        const updatedDeal = await storage.updateDeal(dealId, { status: "verified" });
         
         return res.status(200).json(updatedDeal);
       } catch (error) {
-        console.error("Approve deal error:", error);
+        console.error("Verify deal error:", error);
         return res.status(500).json({ message: "Internal server error" });
       }
     }


### PR DESCRIPTION
## Summary
- Standardize verification statuses to `pending`, `verified`, and `rejected` across deal routes and client pages
- Update admin and vendor interfaces to use `verified` terminology and badges
- Replace legacy approval endpoints with verification logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f5ac86c0832aa6b8e45f426f1101