### PR TITLE
Handle moved file paths in business registration

### DIFF
--- a/server/routes/auth.routes.ts
+++ b/server/routes/auth.routes.ts
@@ -220,7 +220,20 @@ export async function registerBusiness(req: Request, res: Response) {
     const filesToMove = [tempGovernmentIdPath, tempProofOfAddressPath, tempProofOfBusinessPath];
     const movedFiles = await moveFilesToUserFolder(filesToMove, sanitizedBusinessName);
 
-    console.log("Files moved:", Object.values(movedFiles));
+    const governmentIdPath = movedFiles[tempGovernmentIdPath];
+    const proofOfAddressPath = movedFiles[tempProofOfAddressPath];
+    const proofOfBusinessPath = movedFiles[tempProofOfBusinessPath];
+
+    console.log("Files moved:", {
+      governmentIdPath,
+      proofOfAddressPath,
+      proofOfBusinessPath
+    });
+
+    if (!governmentIdPath || !proofOfAddressPath || !proofOfBusinessPath) {
+      console.error("Missing file paths after moving", movedFiles);
+      return res.status(500).json({ message: "Failed to process uploaded documents" });
+    }
 
       // Create business record (NO password fields)
       const businessResult = await client.query(`
@@ -232,9 +245,9 @@ export async function registerBusiness(req: Request, res: Response) {
         RETURNING id
       `, [
         profileId, businessName, businessCategory, email, phone,
-        Object.values(movedFiles)[0],
-        Object.values(movedFiles)[1], 
-        Object.values(movedFiles)[2]
+        governmentIdPath,
+        proofOfAddressPath,
+        proofOfBusinessPath
       ]);
       
       const businessId = businessResult.rows[0].id;


### PR DESCRIPTION
## Summary
- Capture document paths by key after moving files to the user folder
- Use the captured paths in the business insert query
- Add defensive checks for missing file paths before inserting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f8ff60d0832abaa9d548276ea3ad